### PR TITLE
Pin bad dependency

### DIFF
--- a/contracts/swaprouter/Cargo.toml
+++ b/contracts/swaprouter/Cargo.toml
@@ -48,6 +48,7 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 # osmosis-std = { git = "https://github.com/osmosis-labs/osmosis-rust", branch = "sunny/serde-wasm" }
+time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 osmosis-std = { version = "0.1.3" }
 osmo-bindings = { git = "https://github.com/osmosis-labs/bindings", branch = "main" }
 


### PR DESCRIPTION
The current version of osmosis-std generates the following dependency chain: `osmosis-std` -> `cosmos-sdk-proto` -> `tendermint-proto` -> `time` -> `js-sys` -> `wasm-bidngen`. This makes the contract compile to a wasm file that can't be uploaded to the chain (because wasmbindgen is disallowed by wasmd). 

This has temporarily been worked-around upstream by pinning `time` (https://github.com/informalsystems/tendermint-rs/pull/1174/files), but needs a better fix from the `time` package. 

Pinning the version locally adds the same workaround to this contract. We should at a minimum pin the same dependency on `osmosis-std`, and maybe consider removing the dependency on `tendermint-proto` and instead generating the rust files from the protobuf definitions directly (though it might be enough to track closely the latest releases)
