### PR TITLE
Update osmosis-std version

### DIFF
--- a/Beaker.toml
+++ b/Beaker.toml
@@ -1,1 +1,5 @@
 name = "swaprouter"
+
+[console]
+account_namespace = false
+contract_namespace = false

--- a/contracts/swaprouter/Cargo.toml
+++ b/contracts/swaprouter/Cargo.toml
@@ -47,10 +47,7 @@ cw2 = "0.13.2"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
-# osmosis-std = { git = "https://github.com/osmosis-labs/osmosis-rust", branch = "sunny/serde-wasm" }
-time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
-osmosis-std = { version = "0.1.3" }
-osmo-bindings = { git = "https://github.com/osmosis-labs/bindings", branch = "main" }
+osmosis-std = { version = "0.1.4" }
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"

--- a/contracts/swaprouter/src/execute.rs
+++ b/contracts/swaprouter/src/execute.rs
@@ -2,17 +2,15 @@ use std::convert::TryInto;
 use std::str::FromStr;
 
 use cosmwasm_std::{
-    coins, BankMsg, Coin, DepsMut, Env, MessageInfo, Reply, Response, SubMsg, SubMsgResponse,
+    BankMsg, Coin, coins, DepsMut, Env, MessageInfo, Reply, Response, SubMsg, SubMsgResponse,
     SubMsgResult, Uint128,
 };
-
 use osmosis_std::types::osmosis::gamm::v1beta1::{MsgSwapExactAmountInResponse, SwapAmountInRoute};
 
 use crate::contract::SWAP_REPLY_ID;
-use crate::helpers::{check_is_contract_owner, generate_swap_msg, validate_pool_route};
-use crate::state::{SwapMsgReplyState, ROUTING_TABLE, SWAP_REPLY_STATES};
-
 use crate::error::ContractError;
+use crate::helpers::{check_is_contract_owner, generate_swap_msg, validate_pool_route};
+use crate::state::{ROUTING_TABLE, SWAP_REPLY_STATES, SwapMsgReplyState};
 
 pub fn set_route(
     deps: DepsMut,
@@ -96,7 +94,7 @@ pub fn handle_swap_reply(
         return Ok(Response::new().add_message(bank_msg));
     }
 
-    Result::Err(ContractError::FailedSwap {
+    Err(ContractError::FailedSwap {
         reason: msg.result.unwrap_err(),
     })
 }


### PR DESCRIPTION
## What's in this commit
- update osmosis-std version so that it does not contain wasm_bindgen dependency
- clean up imports and unused dependencies
- use the `Coin` type conversion that come with new version of `osmosis-std`