### PR TITLE
modify to use custom query bindings while we wait for stargate queries to be enabled

### DIFF
--- a/.beaker/state.json
+++ b/.beaker/state.json
@@ -1,1 +1,13 @@
-{}
+{
+  "testnet": {
+    "swaprouter": {
+      "code_id": 714,
+      "addresses": {
+        "default": "osmo1ehuscw29t2qzrpkglxcnfcutg7mfdlle7yvk5lhyaf35xunxsekss9ry42"
+      },
+      "proposal": {
+        "store_code": null
+      }
+    }
+  }
+}

--- a/.beaker/state.json
+++ b/.beaker/state.json
@@ -1,13 +1,1 @@
-{
-  "testnet": {
-    "swaprouter": {
-      "code_id": 714,
-      "addresses": {
-        "default": "osmo1ehuscw29t2qzrpkglxcnfcutg7mfdlle7yvk5lhyaf35xunxsekss9ry42"
-      },
-      "proposal": {
-        "store_code": null
-      }
-    }
-  }
-}
+{}

--- a/.beaker/state.json
+++ b/.beaker/state.json
@@ -1,1 +1,13 @@
-{}
+{
+  "testnet": {
+    "swaprouter": {
+      "code_id": 717,
+      "addresses": {
+        "default": "osmo120en3ww06t8s7z0tmfvjqdzp959phvcwwghg59czwusxupdf4vwq5p650p"
+      },
+      "proposal": {
+        "store_code": null
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Cargo.lock
 
 # Ignores local beaker state
 **/state.local.json
+.beaker/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Swaprouter
+---
+Swaprouter helps contract developers figure out which routes their automated swaps should be using on-chain.
+
+The swaps provided by swaprouter are not guaranteed to be the most efficient.
+
+Deployed on testnet: osmo120en3ww06t8s7z0tmfvjqdzp959phvcwwghg59czwusxupdf4vwq5p650p
+Routes in the testnet routing table:
+ - OSMO -> ION
+ - ION -> OSMO
+
+## Usage with rust:
+```rs
+let route_query = QueryRequest::Wasm(WasmQuery::Smart {
+    contract_addr: routing_table_addr,
+    msg: to_binary(&swaprouter::msg::QueryMsg::GetRoute {
+        input_denom: config.source_denom.clone(),
+        output_denom: config.destination_denom.clone(),
+    })?,
+});
+
+let route: swaprouter::msg::GetRouteResponse = deps.querier.query(&route_query)?;
+```
+

--- a/contracts/swaprouter/Cargo.toml
+++ b/contracts/swaprouter/Cargo.toml
@@ -48,7 +48,6 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 # osmosis-std = { git = "https://github.com/osmosis-labs/osmosis-rust", branch = "sunny/serde-wasm" }
-# time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 osmosis-std = { version = "0.1.3" }
 osmo-bindings = { git = "https://github.com/osmosis-labs/bindings", branch = "main" }
 

--- a/contracts/swaprouter/Cargo.toml
+++ b/contracts/swaprouter/Cargo.toml
@@ -48,7 +48,7 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 # osmosis-std = { git = "https://github.com/osmosis-labs/osmosis-rust", branch = "sunny/serde-wasm" }
-time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
+# time = { version = ">=0.3, <0.3.12", default-features = false, features = ["std"] }
 osmosis-std = { version = "0.1.3" }
 osmo-bindings = { git = "https://github.com/osmosis-labs/bindings", branch = "main" }
 

--- a/contracts/swaprouter/src/contract.rs
+++ b/contracts/swaprouter/src/contract.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
     to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
 };
 use cw2::set_contract_version;
+use osmo_bindings::OsmosisQuery;
 
 use crate::error::ContractError;
 use crate::execute::{handle_swap_reply, set_route};
@@ -20,7 +21,7 @@ pub const SWAP_REPLY_ID: u64 = 1u64;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<OsmosisQuery>,
     _env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -40,7 +41,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<OsmosisQuery>,
     _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -55,7 +56,7 @@ pub fn execute(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps<OsmosisQuery>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::GetOwner {} => to_binary(&query_owner(deps)?),
         QueryMsg::GetRoute {
@@ -66,7 +67,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
+pub fn reply(deps: DepsMut<OsmosisQuery>, _env: Env, msg: Reply) -> Result<Response, ContractError> {
     // get intermediate swap reply state. Error if not found.
     let swap_msg_state = SWAP_REPLY_STATES.load(deps.storage, msg.id)?;
 

--- a/contracts/swaprouter/src/contract_tests.rs
+++ b/contracts/swaprouter/src/contract_tests.rs
@@ -1,15 +1,17 @@
-use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Addr, DepsMut};
+use cosmwasm_std::{Addr, DepsMut, from_binary};
+use cosmwasm_std::testing::{mock_env, mock_info};
+use osmo_bindings::OsmosisQuery;
 use osmosis_std::types::osmosis::gamm::v1beta1::SwapAmountInRoute;
 
 use crate::contract;
+use crate::mocks::mock_deps_with_custom_querier;
 use crate::msg::{ExecuteMsg, GetOwnerResponse, GetRouteResponse, InstantiateMsg, QueryMsg};
 
 static CREATOR_ADDRESS: &str = "creator";
 
 // test helper
 #[allow(unused_assignments)]
-fn initialize_contract(deps: DepsMut) -> Addr {
+fn initialize_contract(deps: DepsMut<OsmosisQuery>) -> Addr {
     let msg = InstantiateMsg {
         owner: String::from(CREATOR_ADDRESS),
     };
@@ -23,7 +25,7 @@ fn initialize_contract(deps: DepsMut) -> Addr {
 
 #[test]
 fn proper_initialization() {
-    let mut deps = mock_dependencies();
+    let mut deps = mock_deps_with_custom_querier();
 
     let owner = initialize_contract(deps.as_mut());
 
@@ -36,7 +38,7 @@ fn proper_initialization() {
 
 #[test]
 fn set_routes() {
-    let mut deps = mock_dependencies();
+    let mut deps = mock_deps_with_custom_querier();
 
     let owner = initialize_contract(deps.as_mut());
 

--- a/contracts/swaprouter/src/execute.rs
+++ b/contracts/swaprouter/src/execute.rs
@@ -6,6 +6,7 @@ use cosmwasm_std::{
     SubMsgResult, Uint128,
 };
 
+use osmo_bindings::{ OsmosisQuery};
 use osmosis_std::types::osmosis::gamm::v1beta1::{MsgSwapExactAmountInResponse, SwapAmountInRoute};
 
 use crate::contract::SWAP_REPLY_ID;
@@ -15,7 +16,7 @@ use crate::state::{SwapMsgReplyState, ROUTING_TABLE, SWAP_REPLY_STATES};
 use crate::error::ContractError;
 
 pub fn set_route(
-    deps: DepsMut,
+    deps: DepsMut<OsmosisQuery>,
     info: MessageInfo,
     input_denom: String,
     output_denom: String,
@@ -72,7 +73,7 @@ pub fn trade_with_slippage_limit(
 }
 
 pub fn handle_swap_reply(
-    _deps: DepsMut,
+    _deps: DepsMut<OsmosisQuery>,
     msg: Reply,
     swap_msg_reply_state: SwapMsgReplyState,
 ) -> Result<Response, ContractError> {

--- a/contracts/swaprouter/src/lib.rs
+++ b/contracts/swaprouter/src/lib.rs
@@ -8,6 +8,7 @@ pub mod state;
 
 #[cfg(test)]
 mod contract_tests;
+#[cfg(test)]
 pub mod mocks;
 
 pub use crate::error::ContractError;

--- a/contracts/swaprouter/src/lib.rs
+++ b/contracts/swaprouter/src/lib.rs
@@ -8,5 +8,6 @@ pub mod state;
 
 #[cfg(test)]
 mod contract_tests;
+pub mod mocks;
 
 pub use crate::error::ContractError;

--- a/contracts/swaprouter/src/mocks.rs
+++ b/contracts/swaprouter/src/mocks.rs
@@ -2,8 +2,7 @@ use std::marker::PhantomData;
 
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{
-    to_binary, Coin, ContractResult, OwnedDeps, SystemError,
-    SystemResult, Uint128,
+    to_binary, Coin, ContractResult, OwnedDeps, SystemError, SystemResult, Uint128,
 };
 use osmo_bindings::{OsmosisQuery, PoolStateResponse};
 

--- a/contracts/swaprouter/src/mocks.rs
+++ b/contracts/swaprouter/src/mocks.rs
@@ -1,0 +1,58 @@
+use std::marker::PhantomData;
+
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{
+    to_binary, Coin, ContractResult, OwnedDeps, SystemError,
+    SystemResult, Uint128,
+};
+use osmo_bindings::{OsmosisQuery, PoolStateResponse};
+
+pub fn mock_deps_with_custom_querier(
+) -> OwnedDeps<MockStorage, MockApi, MockQuerier<OsmosisQuery>, OsmosisQuery> {
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: MockQuerier::new(&[]).with_custom_handler(|query| match query {
+            OsmosisQuery::FullDenom {
+                creator_addr: _,
+                subdenom: _,
+            } => SystemResult::Err(SystemError::UnsupportedRequest {
+                kind: "custom".to_string(),
+            }),
+            OsmosisQuery::PoolState { id } => SystemResult::Ok(ContractResult::Ok(
+                to_binary(&PoolStateResponse {
+                    assets: vec![
+                        Coin {
+                            denom: "uosmo".to_string(),
+                            amount: Uint128::from(1000000000u128),
+                        },
+                        Coin {
+                            denom: "uion".to_string(),
+                            amount: Uint128::from(1000000000u128),
+                        },
+                    ],
+                    shares: Coin {
+                        denom: "gamm/pool/".to_string() + &id.to_string(),
+                        amount: Uint128::from(1000000000u128),
+                    },
+                })
+                .unwrap(),
+            )),
+            OsmosisQuery::SpotPrice {
+                swap: _,
+                with_swap_fee: _,
+            } => SystemResult::Err(SystemError::UnsupportedRequest {
+                kind: "custom".to_string(),
+            }),
+            OsmosisQuery::EstimateSwap {
+                sender: _,
+                first: _,
+                route: _,
+                amount: _,
+            } => SystemResult::Err(SystemError::UnsupportedRequest {
+                kind: "custom".to_string(),
+            }),
+        }),
+        custom_query_type: PhantomData,
+    }
+}

--- a/contracts/swaprouter/src/query.rs
+++ b/contracts/swaprouter/src/query.rs
@@ -1,10 +1,11 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{Deps, StdResult};
+use osmo_bindings::OsmosisQuery;
 
 use crate::msg::{GetOwnerResponse, GetRouteResponse};
 use crate::state::{ROUTING_TABLE, STATE};
 
-pub fn query_owner(deps: Deps) -> StdResult<GetOwnerResponse> {
+pub fn query_owner(deps: Deps<OsmosisQuery>) -> StdResult<GetOwnerResponse> {
     let state = STATE.load(deps.storage)?;
 
     Ok(GetOwnerResponse {
@@ -13,7 +14,7 @@ pub fn query_owner(deps: Deps) -> StdResult<GetOwnerResponse> {
 }
 
 pub fn query_route(
-    deps: Deps,
+    deps: Deps<OsmosisQuery>,
     input_token: &str,
     output_token: &str,
 ) -> StdResult<GetRouteResponse> {


### PR DESCRIPTION
This PR modifies the validate route function to use osmo_bindings::OsmosisQuery to validate a route and allows us to deploy on testnet immediately while we wait for stargate queries to be supported

Comments welcome